### PR TITLE
Fixed teammates staying invisible after dying

### DIFF
--- a/hide_teammates.sp
+++ b/hide_teammates.sp
@@ -68,6 +68,8 @@ public void OnPluginStart()
 			}
 		}
 	}
+	
+	HookEvent("player_death", OnPlayerDeath);
 } 
 
 public void OnMapStart()
@@ -265,7 +267,19 @@ public Action Hook_SetTransmit(int target, int client)
 		return Plugin_Handled;
 	}
 	return Plugin_Continue; 
-}  
+}
+
+void OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
+{
+	int victim = GetClientOfUserId(event.GetInt("userid"));
+	if (!victim)
+		return;
+	
+	for (int target = 1; target <= MaxClients; target++)
+	{
+		g_HidePlayers[victim][target] = false;
+	}
+}
 
 public bool OnlyTeam(int client, int target)
 {


### PR DESCRIPTION
I'll let you compile the plugin yourself for security reasons.

This Pull Request fixes the bug where your teammates stayed invisible (not transmitted) after you died if !hide was enabled.

This was caused by the `IsPlayerAlive(client)` condition inside the `HideTimer` timer function.

To fix that, I hooked the `player_death` event and I cleared the g_HidePlayers array for the client that just died.

✅ Compiles fine
✅ Tested in game and works fine